### PR TITLE
Remove black as a prefix color

### DIFF
--- a/run/common/src/rivetbazelutil/common/prefix.py
+++ b/run/common/src/rivetbazelutil/common/prefix.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import threading
 
-COLORS = [str(i) for i in range(30, 38)]
+COLORS = [str(i) for i in range(31, 38)]
 
 
 def _prefix(name, color):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6686189/161339847-96d25a02-ebd1-49ba-9def-3e910d18a050.png)

Looks ugly in dark-themed terminals